### PR TITLE
Add admin CSS troubleshooting analysis

### DIFF
--- a/admin-css-analysis.md
+++ b/admin-css-analysis.md
@@ -1,0 +1,87 @@
+# Analyse: Fehlendes CSS im Magento Admin Dashboard
+
+Basierend auf den vorhandenen Dokumentationen wurde der Magento 2 Shop als reine Backend-Lösung konfiguriert. In *HEADLESS.md* ist festgehalten, dass zahlreiche Frontend-Module deaktiviert wurden, um nur das Admin Dashboard und die API zu betreiben:
+
+```bash
+# Phase 2: Theme und Widget Module
+php bin/magento module:disable \
+    Magento_Theme \
+    Magento_ThemeGraphQl \
+    Magento_Widget \
+    Magento_Cms \
+    Magento_CmsGraphQl \
+    Magento_CmsPageBuilderAnalytics \
+    Magento_CmsUrlRewrite \
+    Magento_CmsUrlRewriteGraphQl \
+    Magento_PageBuilder \
+    Magento_PageBuilderAnalytics \
+    Magento_PageBuilderAdminAnalytics
+```
+
+(Ein Ausschnitt aus *HEADLESS.md*, Zeilen 73‑87)
+
+Außerdem wird in *HEADLESS-OPTIMIZATION.md* explizit erwähnt, dass Frontend-Themes entfernt werden sollen:
+
+```bash
+# Standard-Themes löschen:
+rm -rf pub/static/frontend/
+rm -rf var/view_preprocessed/pub/static/frontend/
+```
+
+(Zeilen 266‑270 in *HEADLESS-OPTIMIZATION.md*)
+
+In der Liste der **Kritischen Module** wird allerdings darauf hingewiesen, dass `Magento_Ui` für die Admin-Oberfläche benötigt wird:
+
+```bash
+### Core Admin
+Magento_Backend          # Admin Panel
+Magento_User            # Admin Users (Problem-Kandidat!)
+Magento_Authorization   # Permissions
+Magento_Security        # Security
+Magento_Ui              # Admin UI Components
+```
+
+(Aus *HEADLESS.md*, Zeilen 110‑118)
+
+Im Dokument *HEADLESS-OPTIMIZATION.md* steht jedoch in der Aufzählung der zu deaktivierenden Frontend-Module auch `Magento_Ui (teilweise - prüfen!)` (Zeile 18). Wenn dieses Modul versehentlich komplett deaktiviert oder bei der Theme-Bereinigung entfernt wurde, lädt das Admin Dashboard keine Stylesheets mehr.
+
+Ein weiterer Hinweis findet sich in *TODO.md*: Dort wird für Wartungsarbeiten empfohlen, nach der DI-Kompilierung das statische Frontend neu zu generieren:
+
+```bash
+# 3. Static Content deployen (falls nötig)
+ssh -i ~/.ssh/id_ed25519 root@165.22.66.230 "cd /var/www/html && sudo -u www-data php bin/magento setup:static-content:deploy -f"
+```
+
+(Zeilen 210‑217 in *TODO.md*)
+
+Wenn das Kommando `setup:static-content:deploy` nicht ausgeführt wurde oder nach dem Löschen der Theme-Verzeichnisse keine neuen statischen Dateien generiert wurden, fehlen die notwendigen CSS-Dateien in `pub/static/adminhtml`. Dies führt ebenfalls dazu, dass das Admin-Panel ohne Styles geladen wird.
+
+## Mögliche Ursachen im Überblick
+
+1. **Deaktivierung von `Magento_Ui` oder abhängigen Modulen**  
+   In den Dokumentationen ist `Magento_Ui` als prüfenswertes Frontend-Modul aufgeführt. Ein versehentliches Deaktivieren würde sämtliche UI-Komponenten des Admin-Bereichs betreffen.
+2. **Gelöschte Theme-Dateien ohne erneuten Static Content Deploy**  
+   Durch das Entfernen der Standard-Themes (siehe *HEADLESS-OPTIMIZATION.md*) können auch Admin-Styles gelöscht worden sein, sofern der Befehl zu generischen Verzeichnissen gegriffen hat. Ohne anschließendes `setup:static-content:deploy` werden die CSS-Dateien nicht neu erstellt.
+3. **Cache oder Berechtigungsprobleme**  
+   Sollten die Caches nicht korrekt geleert oder Dateiberechtigungen falsch gesetzt sein, kann Magento die statischen Dateien nicht bereitstellen.
+
+## Handlungsempfehlungen
+
+1. **Modulstatus prüfen**
+   ```bash
+   php bin/magento module:status Magento_Ui Magento_Backend
+   ```
+   Sicherstellen, dass beide Module aktiviert sind.
+2. **Statische Inhalte neu generieren**
+   ```bash
+   php bin/magento setup:static-content:deploy -f
+   php bin/magento cache:clean && php bin/magento cache:flush
+   ```
+3. **Dateiberechtigungen kontrollieren**
+   ```bash
+   sudo chown -R www-data:www-data pub/static var/view_preprocessed
+   ```
+4. **Browserkonsole und Netzwerkanalyse prüfen**
+   404‑Fehler auf CSS-Dateien deuten auf fehlende oder falsch verlinkte Assets hin.
+
+Durch diese Schritte sollte ersichtlich werden, ob fehlende Module oder nicht generierte statische Inhalte die Ursache für das fehlende CSS im Admin Dashboard sind.


### PR DESCRIPTION
## Summary
- add detailed analysis for missing CSS in Magento admin dashboard

## Testing
- `node test-admin.js` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_b_683f7b60558c832489e948330e5eb83c